### PR TITLE
Replace 'iframe' by 'dlux' in generator call

### DIFF
--- a/app/views/static_pages/dlux.html.erb
+++ b/app/views/static_pages/dlux.html.erb
@@ -11,7 +11,7 @@
 <h2>Generating this bookmarklet</h2>
 
 <pre>
-  <code>rails g easymarklet:iframe fvb_dlux</code>
+  <code>rails g easymarklet:dlux fvb_dlux</code>
 </pre>
 
 <p>


### PR DESCRIPTION
Example for generating dlux bookmarklet at the beginning says:

```
rails g easymarklet:iframe fvb_dlux
```

It should be:

```
rails g easymarklet:dlux fvb_dlux
```

This command appear again below but it's right this time.

Regards
